### PR TITLE
Add /sbin/quotaon for some providers

### DIFF
--- a/nixos.nix
+++ b/nixos.nix
@@ -74,6 +74,9 @@ in {
 
   system.build.binBashWrapper = binBashWrapper;
   system.activationScripts.injectOpenVzScripts = lib.mkForce ''
+    mkdir -p /sbin
+    ln -sf ${pkgs.quota}/bin/quotaon /sbin/quotaon
+
     ln -sf ${binBashWrapper} /bin/bash
     touch /fastboot
   '';

--- a/nixos.nix
+++ b/nixos.nix
@@ -75,6 +75,9 @@ in {
   system.build.binBashWrapper = binBashWrapper;
   system.activationScripts.injectOpenVzScripts = lib.mkForce ''
     mkdir -p /sbin
+    if [ ! -f /sbin/init ]; then
+      ln -sf $systemConfig/init /sbin/init
+    fi
     ln -sf ${pkgs.quota}/bin/quotaon /sbin/quotaon
 
     ln -sf ${binBashWrapper} /bin/bash


### PR DESCRIPTION
Certain providers call `/sbin/quotaon` within guest, probably to setup disk quotas for VPSes. Add a link from `${pkgs.quota}/bin/quotaon` to `/sbin/quotaon` so that VPS starts properly on those providers.

In addition, on config activation, check if `/sbin/init` exists, and link the current config's init script to it if doesn't.

Fix #1 