### PR TITLE
README.md: Add WebHorizon

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ When rebuilding, include `./nixos.nix` in your NixOS configuration.
 - [Gullo's Hosting](https://hosting.gullo.me)
 - [Inception Hosting](https://inceptionhosting.com)
 - [EthernetServers](https://www.ethernetservers.com)
+- [WebHorizon](https://webhorizon.in)
 
 ## FAQ
 


### PR DESCRIPTION
First off, awesome work with the project; have lots of small OpenVZ boxes that I was considering cancelling since I couldn't run NixOS on them but not anymore.

This change adds WebHorizon to the tested providers list, tested on current main (8dfcfe23bbc67ec82a16ac8870a9771a9bf12976). Works out of the box on a 256MB NAT OpenVZ7 machine from, no extra config needed just the one from README.md.