### PR TITLE
README.md Add STRATO

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ When rebuilding, include `./nixos.nix` in your NixOS configuration.
 - [Inception Hosting](https://inceptionhosting.com)
 - [EthernetServers](https://www.ethernetservers.com)
 - [WebHorizon](https://webhorizon.in)
+- [STRATO](https://www.strato.de/)
 
 ## FAQ
 


### PR DESCRIPTION
This change adds [STRATO](https://www.strato.de/) to the list of tested providers.

I tested:
- current main (362e16d)
- on one of their "Linux V10-Servers" (4vCPUs, 4GB RAM).

Works like a charm, just followed the instructions in the README, no extra configuration needed.

Amazing project, thank you!